### PR TITLE
Install jattach by default

### DIFF
--- a/docker/liberica-base/Dockerfile
+++ b/docker/liberica-base/Dockerfile
@@ -69,3 +69,4 @@ RUN ln -s ${GLIBC_PREFIX}/lib/ld-*.so* /lib \
   &&    for pkg in $OPT_PKGS ; do apk --no-cache add $pkg ; done \
   &&    ${GLIBC_PREFIX}/sbin/ldconfig \
   &&    echo 'hosts: files mdns4_minimal [NOTFOUND=return] dns mdns4' > /etc/nsswitch.conf \
+  &&    apk add --no-cache jattach --repository http://dl-cdn.alpinelinux.org/alpine/edge/community/


### PR DESCRIPTION
## 📃 What it does

Install `jattach` on our base images

## 🤔 Why it is important

Gives us a lightweight way to profile production applications and obtain thread/heap dumps when investigating problems
