### PR TITLE
Install tini by default

### DIFF
--- a/docker/liberica-base/Dockerfile
+++ b/docker/liberica-base/Dockerfile
@@ -69,4 +69,6 @@ RUN ln -s ${GLIBC_PREFIX}/lib/ld-*.so* /lib \
   &&    for pkg in $OPT_PKGS ; do apk --no-cache add $pkg ; done \
   &&    ${GLIBC_PREFIX}/sbin/ldconfig \
   &&    echo 'hosts: files mdns4_minimal [NOTFOUND=return] dns mdns4' > /etc/nsswitch.conf \
-  &&    apk add --no-cache jattach --repository http://dl-cdn.alpinelinux.org/alpine/edge/community/
+  &&    apk add --no-cache jattach --repository http://dl-cdn.alpinelinux.org/alpine/edge/community/ \
+  &&    chmod a-x $(which jattach) \
+  &&    apk add --no-cache tini


### PR DESCRIPTION
Tini is actually built into docker now but only exposed as an option for
`docker run`. Kubernetes doesn't expose this and so we need to build it
into the base image instead.

## 📃 What it does

_Summarize the changes this PR will make and the impact on other specific
teams/projects._

## 🤔 Why it is important

_Make a case for merging this work. Give enough context so the reviewer can
clearly understand why this change is valuable._

## ✅ Steps to test or reproduce

_If applicable, outline the steps to test or reproduce the PR._
