### PR TITLE
Reference correct version when checking cache of base image

### DIFF
--- a/docker/build.sh
+++ b/docker/build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e 
 
-ALPINE_IMAGE="alpine:3.17"
+ALPINE_IMAGE="alpine:3.18"
 export REMOTE_REPO=ghcr.io/permutive-engineering
 JRES="11 17 21"
 


### PR DESCRIPTION
## 📃 What it does

Reference correct alpine version when checking cache of base image

## 🤔 Why it is important

Ensures we rebuild when the correct base image has changed
